### PR TITLE
tg 通知代理

### DIFF
--- a/files/notify/Telegram
+++ b/files/notify/Telegram
@@ -9,7 +9,11 @@
 
 start() {
 	local retry='--connect-timeout 3 --retry 5'
-	$CURL $retry -L -o /dev/null -X POST \
+	
+	# 如果 CUESTOM_PROXY 不为空，则添加 -x 参数
+	local proxy_param=${CUESTOM_PROXY:+-x $CUESTOM_PROXY}
+
+	$CURL $retry -L -o /dev/null -X POST $proxy_param \
 		-H 'Content-Type: application/json' \
 		-d '{"chat_id":"'"${CHAT_ID}"'","text":"'"${text}"'","parse_mode":"HTML","disable_notification":"false"}' \
 		--url "https://${custom_domain:-api.telegram.org}/bot${TOKEN}/sendMessage"
@@ -20,6 +24,6 @@ start() {
 ALL_PARAMS="custom_domain text tokens"
 eval "$(JSON_EXPORT "$1")"; shift
 # All external tokens required
-INIT_GLOBAL_VAR TOKEN CHAT_ID
+INIT_GLOBAL_VAR TOKEN CHAT_ID CUESTOM_PROXY
 eval "$tokens"
 start "$@"


### PR DESCRIPTION
可以填入`CUESTOM_PROXY=sokcs5://127.0.0.1:10080`
解决主路由打洞但是因为没有代理无法发送tg通知的问题